### PR TITLE
Restrukturering og utvidelse av MVP-beskrivelse informasjonsmodell

### DIFF
--- a/standarder/infomodell-mvp.md
+++ b/standarder/infomodell-mvp.md
@@ -73,7 +73,6 @@ Dersom modellen krever at informasjonsobjekter skal ha egenskapen `identifikator
 - **«Rike» objekter og relasjoner er begge gyldige måter å håndtere modellen på**  
 Det er likeverdig om kravet "informasjon om aktør som opprettet et informasjonsobjekt" er dekket ved at informasjon ligger direkte som datafeltet `oppretter` på informasjonsobjektet eller det er en henvisning til en hendelse av typen "opprettelse" i `historikk` på informasjonsobjektet, og hendelsen har datafeltet `oppretter` på seg.
 
-
 ### Hvorfor minimumsmodell?
 
 Vi så tidlig at det å dekke hele behovet for å utvikle informasjonsmodell for dokumentasjonssystemer ville bli for stort til at det var egnet å løse hele behovet med en gang. Derfor tar vi i bruk en smidig tilnærming ved å levere biter som kan deles fortløpende slik at flere kan gi tilbakemelding på det vi tenker, og gi verdi fort. Samtidig får vi da bygd erfaring på å jobbe med informasjonsmodellen(e), og en bedre forståelse for totalbehovet. En mindre omfattende modell er også antatt å være enklere å vedlikeholde og tilpasse eventuelle endrede behov enn det en større modell vil være.
@@ -143,7 +142,7 @@ For hver klasse er det definert hvilke egenskaper det skal finnes metadata for p
 
 ![Egenskaper i minimumsmodellen: Egenskaper som ligger på de ulike klassene er utlistet](/standarder/figurer/infomodell-mvp-egenskaper.png)
 
-#### > #### Lesehjelp
+> #### Lesehjelp
 >
 > **Fet:** Gjennomtenkt  
 > _Kursiv:_ Tenking påbegynt  

--- a/standarder/infomodell-mvp.md
+++ b/standarder/infomodell-mvp.md
@@ -69,7 +69,7 @@ Dersom modellen peker på at informasjonsobjekter skal ha egenskapen `tittel`, e
 - **Ikke (pålagt) en-til-en-forhold mellom egenskaper i modellen og datafelt i systemet/datasettet**  
 Et system som legger `tittel` i ulike felter avhengig av typen informasjonsobjekt (f.eks. `sakstittel`, `møtetittel` og `dokumenttittel`) er i henhold til standarden så lenge det er kjent når de ulike feltene er `tittel`. Et system som har `tittel` fordelt på flere datafelter (f.eks. at tittel er "`dokumenttype` om `tema`") vil også være innenfor standarden.
 - **Få/ingen krav til format**  
-Dersom modellen krever at informasjonsobjekter skal ha egenskapen `identifikator` kan løpenummer, UUID og farge alle være gyldige måter å angi hva identifikatoren er, så lenge funksjonelle krav (f.eks. at identifikator skal være kontekstuelt unik) er
+Dersom modellen krever at informasjonsobjekter skal ha egenskapen `identifikator` kan løpenummer, UUID og farge alle være gyldige måter å angi hva identifikatoren er, så lenge funksjonelle krav (f.eks. at identifikator skal være kontekstuelt unik) er ivaretatt.
 - **«Rike» objekter og relasjoner er begge gyldige måter å håndtere modellen på**  
 Det er likeverdig om kravet "informasjon om aktør som opprettet et informasjonsobjekt" er dekket ved at informasjon ligger direkte som datafeltet `oppretter` på informasjonsobjektet eller det er en henvisning til en hendelse av typen "opprettelse" i `historikk` på informasjonsobjektet, og hendelsen har datafeltet `oppretter` på seg.
 

--- a/standarder/infomodell-mvp.md
+++ b/standarder/infomodell-mvp.md
@@ -4,15 +4,83 @@
 
 > Merk: Dette er kun på hypotese-stadiet. Vesentlige endringer kan forekomme.
 
+## Innhold i dokumentet
+<!-- TOC -->
+
+- [Om modellen og arbeidet med den](#om-modellen-og-arbeidet-med-den)
+  - [Hensikt](#hensikt)
+    - [Bruksområde](#bruksomr%C3%A5de)
+    - [Brukstilfeller](#brukstilfeller)
+  - [Semantisk informasjonsmodell](#semantisk-informasjonsmodell)
+    - [Konsekvenser / eksempler](#konsekvenser--eksempler)
+  - [Hvorfor minimumsmodell?](#hvorfor-minimumsmodell)
+    - [Hvordan har vi avgrenset oss?](#hvordan-har-vi-avgrenset-oss)
+    - [Hvorfor har vi ikke avgrenset oss mer?](#hvorfor-har-vi-ikke-avgrenset-oss-mer)
+  - [Tilnærming](#tiln%C3%A6rming)
+    - [Hypotese på format / metamodell](#hypotese-p%C3%A5-format--metamodell)
+- [Selve modellen](#selve-modellen)
+  - [Klasser og egenskaper](#klasser-og-egenskaper)
+  - [Eksempler på bruk](#eksempler-p%C3%A5-bruk)
+
+<!-- /TOC -->
+
+## Om modellen og arbeidet med den
+
 Denne modellen er ment å være MVP for [informasjonsmodell for dokumentasjonssystemer](infomodell-api.md#informasjonsmodell-for-dokumentasjonssystemer).
 
-## Hvorfor minimumsmodell?
+### Hensikt
+
+Minimumsmodellen er lagd for å sikre at **nødvendige** egenskaper for at objekter skal regnes som dokumentasjon (ref. Arkivfaglige hensyn i [forslag til ny Arkivlov (§4)](https://www.regjeringen.no/contentassets/27ee1149002f49788beaf21e56ae7742/hoyringsnotat-5.oktober-.pdf#page=190) / grunnegenskaper for dokumentasjon) er på plass i de systemene som skal ivareta dokumentasjon og i de datasettene som skal regnes som dokumentasjon. Med grunnegenskaper mener vi autentisitet, pålitelighet, integritet og anvendbarhet - ref. ISO 15489 kap 5.2.2.
+
+Mer konkret skal modellen peke på de konkrete metadataene som er **nødvendige** for at en skal kunne fastslå at egenskapene er ivaretatt. I tillegg er modellen en angivelse av hvilke klasser av objekter som bør støttes når innholdet i et system/datasett er dokumentasjon, men den pålegger ikke et hierarki.
+
+#### Bruksområde
+
+Modellen skal brukes i dokumentasjonssystemer som brukes i offentlig sektor.
+
+_Dokumentasjonssystemer_ er definert som "System som forvalter dokumentasjon over tid" (jf. ISO 30300)
+
+_Dokumentasjon_ er definert som "informasjon som en organisasjon eller person produserer, mottar og vedlikeholder som bevis og som et aktivum, som et ledd i å oppfylle rettslige forpliktelser eller i en forretningstransaksjon" (jf. ISO 30300)
+
+Det brede bruksområdet medfører at modellen må være et slags minste felles multiplum av metadata en kan anta at er (eller i det minste bør være) til stede i alle systemer, og at det ikke stilles flere obligatoriske krav enn nødvendig.
+
+#### Brukstilfeller
+
+Følgende brukerhistorier skal løses av modellen:
+
+- Som bestiller av dokumentasjonsløsning i forvaltningen ønsker jeg at standarden stiller krav til systemer slik at jeg kan vite at løsningen jeg anskaffer sørger for at riktige metadata for å dekke (sentrale) faglige krav til arkiv er ivaretatt for informasjonsobjekter i løsningen når jeg skal anskaffe (utvikling av) nytt system for å sikre at løsningen er egnet til at vi som organisasjon oppfyller våre plikter ved å bruke den
+- Som systemansvarlig for dokumentasjonssystem i forvaltningen / utvikler av dokumentasjonssystem / leverandør av felleskomponent ønsker jeg å oppnå/opprettholde semantisk interoperabilitet med systemer som følger standarden når jeg skal (videre-)utvikle datamodell(er) som brukes i mitt system for å sikre effektiv utveksling av dokumentasjon
+- Som leverandør av felleskomponent/fellesløsning eller dokumentasjonssystem ønsker jeg å sikre at krav (f.eks. regelverk) er ivaretatt når jeg skal (videre-)utvikle datamodell(er) som brukes i mitt system for å sikre at min løsning kan spille sammen med andre arkivløsninger
+
+### Semantisk informasjonsmodell
+
+Modellen som lages er en informasjonsmodell på semantisk nivå. Det vil si at modellen skal dekke hvilken informasjon som må/bør være til stede i systemet/datasettet for at det skal ha verdi som dokumentasjon, uten å legge føringer for hvordan systemet/datasettet skal utformes for at nødvendig informasjon er ivaretatt. En modell på semantisk nivå er egnet til å avdekke:
+
+- I et datasett: Vet vi nok om hvert informasonsobjekt til å fastslå at det har verdi som dokumentasjon (=er en record).
+- I et datasystem: Har systemet funksjonalitet (=tar vare på de riktige metadataene) for å ivareta at innholdet er dokumentasjon.
+- I utvikling av et system: Hva (=hvilke metadata) må være på plass for å sørge for at det ivaretar dokumentasjon
+
+Samtidig er det veldig viktig for teamet ikke å miste koblingen til det tekniske nivået, siden det ofte er graden av slik kobling som skiller mellom en modell som kan brukes i praksis og og en som ikke kan det. Dette ivaretas ved at krav som ligger i grenseland mellom funksjonelt og teknisk nivå tas inn i beskrivelser av ulike egenskaper i modellen. Det er også verdt å merke seg at krav til den tekniske implementeringen kan komme som følge av pålagte grensesnitt, uttrekksformat mv.
+
+#### Konsekvenser / eksempler
+
+- **Fri navngiving av datafelter**  
+Dersom modellen peker på at informasjonsobjekter skal ha egenskapen `tittel`, er et system eller datasett i henhold til standarden selv om det relevante feltet heter `title` eller `saksnavn` i systemet. Det viktige er at informasjonen beskrevet som `tittel` i modellen faktisk finnes for de ulike informasjonsobjektene.
+- **Ikke (pålagt) en-til-en-forhold mellom egenskaper i modellen og datafelt i systemet/datasettet**  
+Et system som legger `tittel` i ulike felter avhengig av typen informasjonsobjekt (f.eks. `sakstittel`, `møtetittel` og `dokumenttittel`) er i henhold til standarden så lenge det er kjent når de ulike feltene er `tittel`. Et system som har `tittel` fordelt på flere datafelter (f.eks. at tittel er "`dokumenttype` om `tema`") vil også være innenfor standarden.
+- **Få/ingen krav til format**  
+Dersom modellen krever at informasjonsobjekter skal ha egenskapen `identifikator` kan løpenummer, UUID og farge alle være gyldige måter å angi hva identifikatoren er, så lenge funksjonelle krav (f.eks. at identifikator skal være kontekstuelt unik) er
+- **«Rike» objekter og relasjoner er begge gyldige måter å håndtere modellen på**  
+Det er likeverdig om kravet "informasjon om aktør som opprettet et informasjonsobjekt" er dekket ved at informasjon ligger direkte som datafeltet `oppretter` på informasjonsobjektet eller det er en henvisning til en hendelse av typen "opprettelse" i `historikk` på informasjonsobjektet, og hendelsen har datafeltet `oppretter` på seg.
+
+
+### Hvorfor minimumsmodell?
 
 Vi så tidlig at det å dekke hele behovet for å utvikle informasjonsmodell for dokumentasjonssystemer ville bli for stort til at det var egnet å løse hele behovet med en gang. Derfor tar vi i bruk en smidig tilnærming ved å levere biter som kan deles fortløpende slik at flere kan gi tilbakemelding på det vi tenker, og gi verdi fort. Samtidig får vi da bygd erfaring på å jobbe med informasjonsmodellen(e), og en bedre forståelse for totalbehovet. En mindre omfattende modell er også antatt å være enklere å vedlikeholde og tilpasse eventuelle endrede behov enn det en større modell vil være.
 
 En slik minimumsmodell må finne riktig balanse mellom behovet for å kunne avgrense nok (slik at det ikke blir for omfattende) og behovet for å ikke avgrense for mye (slik at man lager noe som kan brukes).
 
-### Hvordan har vi avgrenset oss?
+#### Hvordan har vi avgrenset oss?
 
 Grunnleggende kan man se for seg to ulike tilnærminger til hvordan man kan komme fram til en verdigivende delmengde av den fullstendige informasjonsmodellen:
 
@@ -21,39 +89,13 @@ Grunnleggende kan man se for seg to ulike tilnærminger til hvordan man kan komm
 
 Vi har vurdert det til at det gir mer verdi totalt sett hvis vi legger funksjonsbasert tilnærming til grunn i første runde, og har derfor landet på en modell som ivaretar «noe» for alle dokumentasjonssystemer framfor noe som ivaretar alt for «noen» systemer.
 
-### Hvorfor har vi ikke avgrenset oss mer?
+#### Hvorfor har vi ikke avgrenset oss mer?
 
 For en funksjonsbasert inndeling vil det være logisk at den første modellen er en grunnmodell eller minimumsmodell. Begge vil være grunnlag som beskriver et minste felles multiplum av egenskaper det må finnes metadata for, og fungerer som grunnlag for ulike utvidelser. Forskjellen på disse modellene (slik vi tolker det) er at en minimumsmodell, i motsetning til en grunnmodell, må være omfattende nok til at den er tilstrekkelig til å dekke noen brukstilfeller. Det er derfor mer verdi i en minimumsmodell enn en grunnmodell.
 
-En konsekvens av at dette skal være en minimumsmodell, ikke en grunnmodell, er at flere egenskaper må være del av modellen. I vår minimumsmodell er dette egenskaper som er betinget obligatoriske eller sterkt anbefalte for å kunne ivareta grunnegenskapene for dokumentasjon (autentisitet, pålitelighet, integritet og anvendbarhet - ref. ISO 15489 kap 5.2.2). Dette er også hovedargumentasjonen for at det er behov for to klasser (registering og aggregering), ikke bare én (dokumentasjonsobjekt).
+En konsekvens av at dette skal være en minimumsmodell, ikke en grunnmodell, er at flere egenskaper må være del av modellen. I vår minimumsmodell er dette egenskaper som er betinget obligatoriske eller sterkt anbefalte for å kunne ivareta grunnegenskapene for dokumentasjon (autentisitet, pålitelighet, integritet og anvendbarhet). Dette er også hovedargumentasjonen for at det er behov for to klasser (registering og aggregering), ikke bare én (dokumentasjonsobjekt).
 
-## Bruksområde
-
-Modellen skal brukes i dokumentasjonssystemer som brukes i offentlig sektor.
-
-_Dokumentasjonssystemer_ er definert som "System som forvalter dokumentasjon over tid" (jf. ISO 30300)
-
-_Dokumentasjon_ er definert som "informasjon som en organisasjon eller person produserer, mottar og vedlikeholder som bevis og som et aktivum, som et ledd i å oppfylle rettslige forpliktelser eller i en forretningstransaksjon" (jf. ISO 30300)
-
-### Brukstilfeller
-
-Følgende brukerhistorier skal løses av modellen:
-
-- Som bestiller av dokumentasjonsløsning i forvaltningen ønsker jeg at standarden stiller krav til systemer slik at jeg kan vite at løsningen jeg anskaffer sørger for at riktige metadata for å dekke (sentrale) faglige krav til arkiv er ivaretatt for informasjonsobjekter i løsningen når jeg skal anskaffe (utvikling av) nytt system for å sikre at løsningen er egnet til at vi som organisasjon oppfyller våre plikter ved å bruke den
-- Som systemansvarlig for dokumentasjonssystem i forvaltningen / utvikler av dokumentasjonssystem / leverandør av felleskomponent ønsker jeg å oppnå/opprettholde semantisk interoperabilitet med systemer som følger standarden når jeg skal (videre-)utvikle datamodell(er) som brukes i mitt system for å sikre effektiv utveksling av dokumentasjon
-- Som leverandør av felleskomponent/fellesløsning eller dokumentasjonssystem ønsker jeg å sikre at krav (f.eks. regelverk) er ivaretatt når jeg skal (videre-)utvikle datamodell(er) som brukes i mitt system for å sikre at min løsning kan spille sammen med andre arkivløsninger
-
-## Noen kjennetegn
-
-- Minste felles multiplum – bør kunne brukes på alt som skal ha verdi som dokumentasjon
-- En modell på semantisk nivå – stiller ikke krav til implementeringen så lenge nødvendige metadata finnes (og kan nyttiggjøres)
-  - «Rike» objekter og relasjoner er begge gyldige måter å håndtere modellen på
-  - Krav til implementeringen KAN komme som følge av pålagte grensesnitt, uttrekksformat mv.
-- Ikke pålagt hierarki – men likevel støtte for at man kan (og bør?) lage aggregeringer av flere objekter
-- Sørger for at **nødvendige** egenskaper for at objekter skal regnes som dokumentasjon (ref. Arkivfaglige hensyn i forslag til ny Arkivlov (§4) / grunnegenskaper for dokumentasjon) er på plass
-- Peker på de konkrete metadataene som er **nødvendige** for at en skal kunne fastslå at egenskapene er ivaretatt
-
-## Tilnærming
+### Tilnærming
 
 - Vi starter fra grunnen med å definere metadatabehovene
 - ISO 23081-2 vil benyttes som første kilde til hvilke typer metadata som er nødvendig
@@ -62,7 +104,7 @@ Følgende brukerhistorier skal løses av modellen:
   2. Faglig diskusjon rundt hvilke metadata som er **nødvendige** og relasjon til mer omfattende standarder ([CITS ERMS](https://dilcis.eu/content-types/cserms) og [Noark](https://www.arkivverket.no/forvaltning-og-utvikling/noark-standarden/noark5-standarden))
 - Sammenligning og sammenslåing av resultatet fra de to tilnærmingene.
 
-### Hypotese på format / metamodell
+#### Hypotese på format / metamodell
 
 Formatet vil ligne noe på Noark metadatakatalog objektsortert - det vil si at utgangspunktet er at det finnes ulike objekttyper/klasser, og for hver objekttype vil det være spesifisert hvilke egenskaper/metadata som skal/bør være definert for det enkelte objekt av typen. Vi ser for oss tre typer/klasser - registering/record (et generisk enkelt informasjonsobjekt), aggregering (en generisk samling av informasjonsobjekter) og hendelse (en beskrivelse av noe som har skjedd (potensielt også skal skje) med en record eller aggregering).
 
@@ -79,7 +121,9 @@ For hver egenskap vil følgende beskrives:
   - Integritet
 - Begrunnelse - beskrivelse av hvorfor egenskapen trenger være del av minimumsmodellen
 
-## Klasser og egenskaper
+## Selve modellen
+
+### Klasser og egenskaper
 
 Som nevnt over er det to klasser for dokumentasjonsobjekter - aggregering og registrering. Sammenhengen mellom dem kan illustreres slik:
 
@@ -99,10 +143,12 @@ For hver klasse er det definert hvilke egenskaper det skal finnes metadata for p
 
 ![Egenskaper i minimumsmodellen: Egenskaper som ligger på de ulike klassene er utlistet](/standarder/figurer/infomodell-mvp-egenskaper.png)
 
-> **Lesehjelp:**  
-> Fet: Gjennomtenkt  
-> Kursiv: Tenking påbegynt  
-> Asterisk: Obligatorisk på det enkelte objekt  
+#### > #### Lesehjelp
+>
+> **Fet:** Gjennomtenkt  
+> _Kursiv:_ Tenking påbegynt  
+> Asterisk (*): Obligatorisk på det enkelte objekt
+>
 > NB! Alt fortsatt åpent for diskusjon
 
 ### Eksempler på bruk


### PR DESCRIPTION
- Endret rekkefølge på innholdselementer (for at kontekst skal være lettere å forstå)
- Lagt til informasjon om semantisk informasjonsmodell (og konsekvenser av dette)
- Erstattet "noen kjennetegn" med mer fullverdige beskrivelser
- Lagt til innholdsfortegnelse
